### PR TITLE
Updated mobile app template to use latest ionic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ the following changelog guidelines: http://keepachangelog.com/
 
 ## [Unreleased]
 
+## [0.5.8] - 2016-08-09
+- Updated the mobile app template to reference the latest 1.x verison of ionic, 1.3.1. `ionic-sdk` npm package was abandoned and all new versions are now u nder the `ionic-angular` npm package. See: https://github.com/driftyco/ionic/issues/6578
+
 ## [0.5.7] - 2016-07-28
 - Added another missing conditional in the template for the --directive option.
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ the following changelog guidelines: http://keepachangelog.com/
 ## [Unreleased]
 
 ## [0.5.8] - 2016-08-09
-- Updated the mobile app template to reference the latest 1.x verison of ionic, 1.3.1. `ionic-sdk` npm package was abandoned and all new versions are now u nder the `ionic-angular` npm package. See: https://github.com/driftyco/ionic/issues/6578
+- Updated the mobile app template to reference the latest 1.x version of ionic, 1.3.1. `ionic-sdk` npm package was abandoned and all new versions are now under the `ionic-angular` npm package. See: https://github.com/driftyco/ionic/issues/6578
 
 ## [0.5.7] - 2016-07-28
 - Added another missing conditional in the template for the --directive option.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng6-cli",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Tooling to build applications with Angular 1.5, ES6, and Webpack.",
   "main": "index.js",
   "bin": {

--- a/templates/app/ionic/template/app/app.module.js
+++ b/templates/app/ionic/template/app/app.module.js
@@ -3,7 +3,7 @@ console.log('application loading...');
 import angular from 'angular';
 import uiRouter from 'angular-ui-router';
 import animate from 'angular-animate';
-import 'ionic-sdk/release/js/ionic.bundle';
+import 'ionic-angular/release/js/ionic.bundle';
 import AppStyles from '../styles/app.scss';
 import AppComponent from './app.component';
 

--- a/templates/app/ionic/template/package.json
+++ b/templates/app/ionic/template/package.json
@@ -27,7 +27,7 @@
     "angular": "1.5.7",
     "angular-animate": "1.5.7",
     "angular-ui-router": "0.3.1",
-    "ionic-sdk": "1.2.4",
+    "ionic-angular": "1.3.1",
     "oclazyload": "1.0.9"
   },
   "cordovaPlugins": [


### PR DESCRIPTION
Updated the mobile app template to reference the latest 1.x version of ionic, 1.3.1. `ionic-sdk` npm package was abandoned and all new versions are now under the `ionic-angular` npm package. See: https://github.com/driftyco/ionic/issues/6578