### PR TITLE
Use webpack-validator instead of custom validator for better output

### DIFF
--- a/commands/build/command.js
+++ b/commands/build/command.js
@@ -3,8 +3,7 @@ var path = require('path');
 var chalk = require('chalk');
 var webpack = require('webpack');
 var Command = require('../../lib/command');
-var WebpackValidator = require('../../lib/webpack-validator');
-var webpackValidator = new WebpackValidator();
+var validateWebpack = require('../../lib/webpack-validator');
 
 module.exports = Command.extend({
 
@@ -39,12 +38,7 @@ module.exports = Command.extend({
       webpackConfig = require(webpackRoot);
     }
 
-    if( !webpackValidator.check(webpackConfig) ) {
-      console.log('');
-      console.log(chalk.white('The webpack configuration does not appear to be valid!'));
-      console.log('');
-      process.exit(1);
-    }
+    validateWebpack(webpackConfig);
 
     var bundler = webpack(webpackConfig);
 

--- a/commands/serve/command.js
+++ b/commands/serve/command.js
@@ -2,8 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var chalk = require('chalk');
 var Command = require('../../lib/command');
-var WebpackValidator = require('../../lib/webpack-validator');
-var webpackValidator = new WebpackValidator();
+var webpackValidate = require('../../lib/webpack-validator');
 
 //todo: resolve issue with executing serve from somewhere other than project root.
 //todo: support custom server?
@@ -69,12 +68,7 @@ module.exports = Command.extend({
       webpackConfig = require(webpackRoot);
     }
 
-    if( !webpackValidator.check(webpackConfig) ) {
-      console.log('');
-      console.log(chalk.white('The webpack configuration does not appear to be valid!'));
-      console.log('');
-      process.exit(1);
-    }
+    webpackValidate(webpackConfig)
 
     //require browser sync along with webpack and middleware for it
     var browserSync = require('browser-sync').create();

--- a/lib/webpack-validator.js
+++ b/lib/webpack-validator.js
@@ -1,35 +1,11 @@
-var BaseClass = require('ouro-base');
-var _ = require('lodash');
+const validate = require('webpack-validator');
+const Joi = require('webpack-validator').Joi;
 
-module.exports = BaseClass.extend({
-
-  init: function() {
-
-  },
-
-  check: function(webpackConfig) {
-
-    if( !_.isObject(webpackConfig) ) {
-      return false;
-    }
-
-    if( !_.isObject(webpackConfig.entry) ) {
-      return false;
-    }
-
-    if( !_.isObject(webpackConfig.output) ) {
-      return false;
-    }
-
-    if( !_.isObject(webpackConfig.module) ) {
-      return false;
-    }
-
-    if( !_.isArray(webpackConfig.module.loaders) ) {
-      return false;
-    }
-
-    return true;
-  }
-
+// This joi schema will be `Joi.concat`-ed with the internal schema
+const schemaExtension = Joi.object({
+  sassResources: Joi.any() // this would just allow the property and doesn't perform any additional validation
 });
+
+module.exports = function(config) {
+  validate(config, { schemaExtension: schemaExtension });
+}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ouro-base": "0.9.0",
     "shelljs": "0.6.0",
     "webpack": "1.12.15",
-    "webpack-dev-middleware": "1.6.1",
+    "webpack-validator": "^2.2.9",
     "yargs": "4.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This replaces our custom webpack validator with [webpack-validator](https://www.npmjs.com/package/webpack-validator). This will give us better output and feedback when the `webpack.config`'s are changed incorrectly. This will happen for both `ng6 serve` and `ng6 build`.

Sample output looks like this:

<img width="360" alt="screen shot 2016-10-26 at 10 10 23 am" src="https://cloud.githubusercontent.com/assets/7402211/19730107/24783eee-9b67-11e6-967b-b5a4cd931286.png">
