### PR TITLE
add --skip-validate flag to skip webpack validations

### DIFF
--- a/commands/build/command.js
+++ b/commands/build/command.js
@@ -4,7 +4,7 @@ var spawn = require('child_process').spawn;
 var chalk = require('chalk');
 var webpack = require('webpack');
 var Command = require('../../lib/command');
-var validateWebpack = require('../../lib/webpack-validator');
+var webpackValidate = require('../../lib/webpack-validator');
 
 module.exports = Command.extend({
 
@@ -39,7 +39,9 @@ module.exports = Command.extend({
       webpackConfig = require(webpackRoot);
     }
 
-    validateWebpack(webpackConfig);
+    if( !this.cli.isEnabled('skip-validate') ){
+      webpackValidate(webpackConfig);
+    }
 
     console.log(chalk.white('Building project with webpack by running `npm run build`'));
     console.log('');

--- a/commands/serve/command.js
+++ b/commands/serve/command.js
@@ -68,10 +68,12 @@ module.exports = Command.extend({
       webpackConfig = require(webpackRoot);
     }
 
-    webpackValidate(webpackConfig)
+    if( !this.cli.isEnabled('skip-validate') ){
+      webpackValidate(webpackConfig);
+    }
 
     const serveProcess = spawn('npm', ['run', 'serve'], { stdio: 'inherit' });
-    
+
   }
 
 });


### PR DESCRIPTION
now for `ng6 serve/build` you can add a `--skip-validate` in order to skip the webpack validation. This can be helpful because if adding a new field like `sassResources` or something like that to the webpack config can cause the serving/building with `ng6` to fail. And currently the only way to fix would be to submit a PR here. So we should allow people to skip the webpack validation if necessary.

Also while on the subject currently the way of extending the `webpack-validator` is by using it's api to add a Joi object. Like so

```javascript
const schemaExtension = Joi.object({
  sassResources: Joi.any() // this would just allow the property and doesn't perform any additional validation
});
```

So maybe a way of extensibility would be to allow for creating a webpack-validation file which gets pulled in and replaces this Joi object at runtime?