### PR TITLE
make webpack-dashboard optional with --skip-dashboard flag

### DIFF
--- a/commands/serve/command.js
+++ b/commands/serve/command.js
@@ -72,7 +72,14 @@ module.exports = Command.extend({
       webpackValidate(webpackConfig);
     }
 
-    const serveProcess = spawn('npm', ['run', 'serve'], { stdio: 'inherit' });
+    let serveProcess;
+    if( this.cli.isEnabled('skip-dashboard') ){
+      serveProcess = spawn('npm', ['run', 'skip-dash'], { stdio: 'inherit' });
+    } else {
+      serveProcess = spawn('npm', ['run', 'serve'], { stdio: 'inherit' });
+    }
+
+
 
   }
 

--- a/commands/serve/command.js
+++ b/commands/serve/command.js
@@ -73,8 +73,8 @@ module.exports = Command.extend({
     }
 
     let serveProcess;
-    if( this.cli.isEnabled('skip-dashboard') ){
-      serveProcess = spawn('npm', ['run', 'skip-dash'], { stdio: 'inherit' });
+    if( this.cli.isEnabled('dashboard') ){
+      serveProcess = spawn('npm', ['run', 'dashboard'], { stdio: 'inherit' });
     } else {
       serveProcess = spawn('npm', ['run', 'serve'], { stdio: 'inherit' });
     }

--- a/templates/app/ionic/template/package.json
+++ b/templates/app/ionic/template/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "prebuild": "rimraf www",
     "build": "cross-env NODE_ENV=production webpack --bail -p --config webpack.prod.config.js",
-    "skip-dash": "webpack-dev-server",
-    "serve": "webpack-dashboard -- npm run skip-dash",
+    "dash": "webpack-dashboard -- npm run serve",
+    "serve": "webpack-dev-server",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint --format './node_modules/eslint-teamcity/index.js' .",

--- a/templates/app/ionic/template/package.json
+++ b/templates/app/ionic/template/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "prebuild": "rimraf www",
     "build": "cross-env NODE_ENV=production webpack --bail -p --config webpack.prod.config.js",
-    "serve": "webpack-dashboard -- webpack-dev-server",
+    "skip-dash": "webpack-dev-server",
+    "serve": "webpack-dashboard -- npm run skip-dash",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint --format './node_modules/eslint-teamcity/index.js' .",

--- a/templates/app/web/template/package.json
+++ b/templates/app/web/template/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "prebuild": "rimraf build",
     "build": "cross-env NODE_ENV=production webpack --bail -p --config webpack.prod.config.js",
-    "serve": "webpack-dashboard -- webpack-dev-server",
+    "skip-dash": "webpack-dev-server",
+    "serve": "webpack-dashboard -- npm run skip-dash",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint --format './node_modules/eslint-teamcity/index.js' .",

--- a/templates/app/web/template/package.json
+++ b/templates/app/web/template/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "prebuild": "rimraf build",
     "build": "cross-env NODE_ENV=production webpack --bail -p --config webpack.prod.config.js",
-    "skip-dash": "webpack-dev-server",
-    "serve": "webpack-dashboard -- npm run skip-dash",
+    "dashboard": "webpack-dashboard -- npm run serve",
+    "serve": "webpack-dev-server",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint --format './node_modules/eslint-teamcity/index.js' .",


### PR DESCRIPTION
one can now provide `ng6 serve --skip-dashboard` to skip the use of webpack-dashboard because it can cause issues on some terminal's or terminal emulators such as WebStorm's