### PR TITLE
Added support for win32 machines when spawning processes

### DIFF
--- a/commands/build/command.js
+++ b/commands/build/command.js
@@ -46,7 +46,7 @@ module.exports = Command.extend({
     console.log(chalk.white('Building project with webpack by running `npm run build`'));
     console.log('');
 
-    const serveProcess = spawn('npm', ['run', 'build'], { stdio: 'inherit' });
+    const serveProcess = spawn('npm', ['run', 'build'], { stdio: 'inherit', shell: true });
 
   }
 });


### PR DESCRIPTION
Fix for #29 per https://github.com/nodejs/node-v0.x-archive/issues/2318#issuecomment-263852511

Another solution is this npm package: https://www.npmjs.com/package/cross-spawn

