### PR TITLE
Added hash to image loader so that there aren't name collisions

### DIFF
--- a/templates/app/ionic/template/webpack.config.js
+++ b/templates/app/ionic/template/webpack.config.js
@@ -158,7 +158,7 @@ module.exports = (env) => {
           loader: 'url-loader',
           options: {
             limit: 1024,
-            name: 'images/[name].[ext]',
+            name: 'images/[name].[hash].[ext]',
           },
         },
         {

--- a/templates/app/web/template/webpack.config.js
+++ b/templates/app/web/template/webpack.config.js
@@ -158,7 +158,7 @@ module.exports = (env) => {
           loader: 'url-loader',
           options: {
             limit: 1024,
-            name: 'images/[name].[ext]',
+            name: 'images/[name].[hash].[ext]',
           },
         },
         {


### PR DESCRIPTION
If you had two files with the same name in different directories:

`import image from '../assets/images/cool-image.jpg'`
`import totallyDifferentImage from '../assets/images/neat-folder/cool-image.jpg'

Only one of the images would end up in the build as `images/cool-image.jpg`

Adding a hash into the file name fixes it.